### PR TITLE
Load Bundle Services

### DIFF
--- a/DependencyInjection/AimeosShopExtension.php
+++ b/DependencyInjection/AimeosShopExtension.php
@@ -36,6 +36,9 @@ class AimeosShopExtension extends Extension
 		foreach( $config as $key => $value ) {
 			$container->setParameter( 'aimeos_shop.' . $key, $value );
 		}
+
+		$loader = new Loader\YamlFileLoader( $container, new FileLocator( __DIR__ . '/../Resources/config' ) );
+		$loader->load( 'services.yml' );
 	}
 
 


### PR DESCRIPTION
Load the services defined in the `services.yml` configuration file from inside the bundle's DI extension class. This prevents errors during installation (service *aimeos_context* not defined) and on pages such as `/list` (service *aimeos_page* not defined).

If this omission was meant to be like this, could you update the documentation to specify how services were intended to be loaded :)